### PR TITLE
Python 3 support and re-write of class factory

### DIFF
--- a/src/dia/dia_renderer.py
+++ b/src/dia/dia_renderer.py
@@ -131,7 +131,8 @@ class MyPyRenderer(ObjRenderer):
         s = ""
         s += "import numpy as np\n"
         s += "import datetime\n"
-        s += "from spectroscopy.class_factory import _class_factory\n" 
+        s += "from spectroscopy.class_factory import _base_class_factory, "
+        s += "_buffer_class_factory\n"
         return s
 
     def build_documentation(self,k):
@@ -167,8 +168,7 @@ class MyPyRenderer(ObjRenderer):
                        'json':'np.str_', 'set':'set'}
         d = {}
         s = "\n\n"
-        s += "__{0:s} = _class_factory('__{0:s}', '{1:s}',\n".format(k.name,k.stereotype)
-        s += "\tclass_attributes=[\n"
+        s += "__{0:s} = _base_class_factory('__{0:s}', '{1:s}',\n".format(k.name,k.stereotype)
         attributes = []
         for n,att in k.attributes:
             if n in ['resource_id', 'creation_time', 'modification_time']:
@@ -185,12 +185,14 @@ class MyPyRenderer(ObjRenderer):
                 dt = "({:s},)".format(type_lookup[att[0].strip()])
             attributes.append("('{0:s}',{1:s})".format(n,dt))
         i = 0
+        cls_attrs = "\tclass_attributes=[\n"
         for a in attributes:
             i += 1
-            s += "\t\t{:s}".format(a)
+            cls_attrs += "\t\t{:s}".format(a)
             if i < len(attributes):
-                s += ",\n"
-        s += "],\n"
+                cls_attrs += ",\n"
+        cls_attrs += "],\n"
+        s += cls_attrs
 
         references = []
         # Dependencies have to be tracked so the 
@@ -211,22 +213,24 @@ class MyPyRenderer(ObjRenderer):
                     dependencies.append("_{:s}".format(ref_class))
                 references.append("('{0:s}',{1:s})".format(n,dt))
 
+        cls_refs = "\tclass_references=[\n" 
         if len(references) > 0:
             i = 0
-            s += "\tclass_references=[\n"
             for r in references:
                 i += 1
-                s += "\t\t{:s}".format(r)
+                cls_refs += "\t\t{:s}".format(r)
                 if i < len(references):
-                    s += ",\n"
-            s += "])\n"
+                    cls_refs += ",\n"
+            cls_refs += "])\n"
         else:
-            s += "\tclass_references=[])\n"
-
+            cls_refs = "\tclass_references=[])\n"
+        s += cls_refs
+ 
         s += "\n\n"
-        s += "__{0:s}Buffer = _class_factory(\n".format(k.name)
-        s += "\t'__{0:s}Buffer', 'buffer',\n".format(k.name)
-        s += "\t__{0:s}._properties, __{0:s}._references)\n".format(k.name)
+        s += "__{0:s}Buffer = _buffer_class_factory(\n".format(k.name)
+        s += "\t'__{0:s}Buffer', \n".format(k.name)
+        s += cls_attrs
+        s += cls_refs
         s += "\n\n"
         s += "class {0:s}Buffer(__{0:s}Buffer):\n".format(k.name)
         s += self.build_documentation(k)

--- a/src/dia/dia_renderer.py
+++ b/src/dia/dia_renderer.py
@@ -1,11 +1,12 @@
 import re
 import dia
 
+
 class Klass:
     def __init__(self, name):
         self.name = name
         self.stereotype = None
-        # use a list to preserve the order		
+        # use a list to preserve the order
         self.attributes = []
         # a list, as java/c++ support multiple methods with the same name
         self.operations = []
@@ -14,13 +15,18 @@ class Klass:
         self.templates = []
         self.inheritance_type = ""
 
-    def AddAttribute(self, name, type, visibility, value, comment, class_scope):
-        self.attributes.append((name, (type, visibility, value, comment, class_scope)))
+    def AddAttribute(self, name, type, visibility,
+                     value, comment, class_scope):
+        self.attributes.append((name, (type, visibility, value,
+                                       comment, class_scope)))
 
-    def AddOperation(self, name, type, visibility, params, inheritance_type, comment, class_scope):
-        self.operations.append((name,(type, visibility, params, inheritance_type, comment, class_scope)))
+    def AddOperation(self, name, type, visibility, params, inheritance_type,
+                     comment, class_scope):
+        self.operations.append((name, (type, visibility, params,
+                                       inheritance_type, comment,
+                                       class_scope)))
 
-    def SetComment(self, s) :
+    def SetComment(self, s):
         self.comment = s
 
     def AddParrent(self, parrent):
@@ -36,23 +42,28 @@ class Klass:
         self.stereotype = stereotype
 
 
-class ObjRenderer :
-    "Implements the Object Renderer Interface and transforms diagram into its internal representation"
-    def __init__ (self) :
+class ObjRenderer:
+    """
+    Implements the Object Renderer Interface and transforms
+    diagram into its internal representation
+    """
+    def __init__(self):
         self.klasses = {}
         self.arrows = []
         self.filename = ""
 
-    def begin_render (self, data, filename) :
+    def begin_render(self, data, filename):
         self.filename = filename
-        # not only reset the filename but also the other state, otherwise we would accumulate information through every export
+        # not only reset the filename but also the other state,
+        # otherwise we would accumulate information through every export
         self.klasses = {}
         self.arrows = []
-        for layer in data.layers :
-            # for the moment ignore layer info. But we could use this to spread accross different files
-            for o in layer.objects :
-                if o.type.name == "UML - Class" :
-                    #print o.properties["name"].value
+        for layer in data.layers:
+            # for the moment ignore layer info. But we could use this
+            # to spread accross different files
+            for o in layer.objects:
+                if o.type.name == "UML - Class":
+                    # print o.properties["name"].value
                     k = Klass(o.properties["name"].value)
                     k.SetComment(o.properties["comment"].value)
                     k.SetStereotype(o.properties["stereotype"].value)
@@ -60,44 +71,55 @@ class ObjRenderer :
                         k.SetInheritance_type("abstract")
                     if o.properties["template"].value:
                         k.SetInheritance_type("template")
-                    for op in o.properties["operations"].value :
-                        # op : a tuple with fixed placing, see: objects/UML/umloperations.c:umloperation_props
-                        # (name, type, comment, stereotype, visibility, inheritance_type, class_scope, params)
+                    for op in o.properties["operations"].value:
+                        # op : a tuple with fixed placing,
+                        # see: objects/UML/umloperations.c:umloperation_props
+                        # (name, type, comment, stereotype, visibility,
+                        # inheritance_type, class_scope, params)
                         params = []
-                        for par in op[8] :
-                            # par : again fixed placement, see objects/UML/umlparameter.c:umlparameter_props
+                        for par in op[8]:
+                            # par : again fixed placement,
+                            # see objects/UML/umlparameter.c:umlparameter_props
                             # (name, type, value, comment, kind)
-                            params.append((par[0], par[1], par[2], par[3], par[4]))
-                        k.AddOperation (op[0], op[1], op[4], params, op[5], op[2], op[7])
-                        #print o.properties["attributes"].value
-                    for attr in o.properties["attributes"].value :
+                            params.append((par[0], par[1], par[2], par[3],
+                                           par[4]))
+                        k.AddOperation(op[0], op[1], op[4], params, op[5],
+                                       op[2], op[7])
+                        # print o.properties["attributes"].value
+                    for attr in o.properties["attributes"].value:
                         # see objects/UML/umlattributes.c:umlattribute_props
-                        #print "\t", attr[0], attr[1], attr[4]
-                        # name, type, value, comment, visibility, abstract, class_scope
-                        k.AddAttribute(attr[0], attr[1], attr[4], attr[2], attr[3], attr[6])
+                        # print "\t", attr[0], attr[1], attr[4]
+                        # name, type, value, comment, visibility, abstract,
+                        # class_scope
+                        k.AddAttribute(attr[0], attr[1], attr[4], attr[2],
+                                       attr[3], attr[6])
                     self.klasses[o.properties["name"].value] = k
-                #Connections
-                elif o.type.name == "UML - Association" :
+                # Connections
+                elif o.type.name == "UML - Association":
                     # should already have got attributes relation by names
                     pass
                 # other UML objects which may be interesting
-                # UML - Note, UML - LargePackage, UML - SmallPackage, UML - Dependency, ...
-        
+                # UML - Note, UML - LargePackage, UML - SmallPackage,
+                # UML - Dependency, ...
+
         edges = {}
-        for layer in data.layers :
-            for o in layer.objects :
+        for layer in data.layers:
+            for o in layer.objects:
                 for c in o.connections:
                     for n in c.connected:
-                        if not n.type.name in ("UML - Generalization", "UML - Realizes"):
+                        if n.type.name not in ("UML - Generalization",
+                                               "UML - Realizes"):
                             continue
                         if str(n) in edges:
                             continue
                         edges[str(n)] = None
-                        if not (n.handles[0].connected_to and n.handles[1].connected_to):
+                        if not (n.handles[0].connected_to and (n.handles[1].
+                                                               connected_to)):
                             continue
                         par = n.handles[0].connected_to.object
                         chi = n.handles[1].connected_to.object
-                        if not par.type.name == "UML - Class" and chi.type.name == "UML - Class":
+                        if not par.type.name == "UML - Class" and\
+                           chi.type.name == "UML - Class":
                             continue
                         par_name = par.properties["name"].value
                         chi_name = chi.properties["name"].value
@@ -105,19 +127,19 @@ class ObjRenderer :
                             self.klasses[chi_name].AddParrent(par_name)
                         else:
                             self.klasses[chi_name].AddTemplate(par_name)
-                                    
-    def end_render(self) :
+
+    def end_render(self):
         # without this we would accumulate info from every pass
         self.attributes = []
         self.operations = []
 
-    def draw_line(self,*args):
+    def draw_line(self, *args):
         pass
 
-    def draw_string(self,*args):
+    def draw_string(self, *args):
         pass
 
-    def fill_rect(self,*args):
+    def fill_rect(self, *args):
         pass
 
 
@@ -135,14 +157,14 @@ class MyPyRenderer(ObjRenderer):
         s += "_buffer_class_factory\n"
         return s
 
-    def build_documentation(self,k):
+    def build_documentation(self, k):
         """
         Construct sphynx-compatible documentation from datamodel
         comments.
         """
         s = "\t'''\n"
         s += "\t{:s}\n\n".format(k.comment)
-        for n,att in k.attributes:
+        for n, att in k.attributes:
             if n in ['resource_id', 'creation_time', 'modification_time']:
                 continue
             if att[0].find('array') != -1:
@@ -153,67 +175,71 @@ class MyPyRenderer(ObjRenderer):
                 dt = "int"
             else:
                 dt = att[0]
-            s += "\t:type {0:s}: {1:s}\n".format(n,dt)
-            s += "\t:param {0:s}: {1:s}\n".format(n,att[3]) 
+            s += "\t:type {0:s}: {1:s}\n".format(n, dt)
+            s += "\t:param {0:s}: {1:s}\n".format(n, att[3])
         s += "\t'''"
         return s
 
     def build_classes(self, k):
         """
-        Generate the code that calls the class factory function and 
+        Generate the code that calls the class factory function and
         builds the different variety of classes from the datamodel.
         """
-        type_lookup = {'float':'np.float_', 'integer':'np.int_', 
-                       'string':'np.str_', 'datetime':'datetime.datetime',
-                       'json':'np.str_', 'set':'set'}
+        type_lookup = {'float': 'np.float_', 'integer': 'np.int_',
+                       'string': 'np.str_', 'datetime': 'datetime.datetime',
+                       'json': 'np.str_', 'set': 'set'}
         d = {}
         s = "\n\n"
-        s += "__{0:s} = _base_class_factory('__{0:s}', '{1:s}',\n".format(k.name,k.stereotype)
+        tmp_s = "__{0:s} = _base_class_factory('__{0:s}', '{1:s}',\n"
+        s += tmp_s.format(k.name, k.stereotype)
         attributes = []
-        for n,att in k.attributes:
+        for n, att in k.attributes:
             if n in ['resource_id', 'creation_time', 'modification_time']:
                 continue
             if att[0].find('reference') != -1:
                 continue
             if att[0].find('array') != -1:
                 try:
-                    dtp = re.match('array of (\w+)s',att[0]).group(1)
-                except Exception,e:
+                    dtp = re.match('array of (\w+)s', att[0]).group(1)
+                except Exception as e:
                     raise Exception("Can't match {:s}".format(att[0]))
                 dt = "(np.ndarray, {:s})".format(type_lookup[dtp])
             else:
                 dt = "({:s},)".format(type_lookup[att[0].strip()])
-            attributes.append("('{0:s}',{1:s})".format(n,dt))
+            attributes.append("('{0:s}',{1:s})".format(n, dt))
         i = 0
-        cls_attrs = "\tclass_attributes=[\n"
+        cls_props = "\tclass_properties=[\n"
         for a in attributes:
             i += 1
-            cls_attrs += "\t\t{:s}".format(a)
+            cls_props += "\t\t{:s}".format(a)
             if i < len(attributes):
-                cls_attrs += ",\n"
-        cls_attrs += "],\n"
-        s += cls_attrs
+                cls_props += ",\n"
+        cls_props += "],\n"
+        s += cls_props
 
         references = []
-        # Dependencies have to be tracked so the 
+        # Dependencies have to be tracked so the
         # classes are build in the right order
         dependencies = []
-        for n,att in k.attributes:
+        for n, att in k.attributes:
             if att[0].find('reference') != -1:
                 if att[0].startswith('array'):
-                    dtp = re.match('array of references to (\w+)',att[0]).group(1)
+                    dtp = re.match('array of references to (\w+)',
+                                   att[0]).group(1)
                     dt = "(np.ndarray, _{:s})".format(dtp)
                     dependencies.append("_{:s}".format(dtp))
                 else:
                     try:
-                        ref_class = re.match("reference to (\S*)",att[0]).group(1)
+                        ref_class = re.match("reference to (\S*)",
+                                             att[0]).group(1)
                     except AttributeError:
-                        print "No reference class found in {:s}".format(att[0])
+                        msg = "No reference class found in {:s}".format(att[0])
+                        print(msg)
                     dt = "(_{:s},)".format(ref_class)
                     dependencies.append("_{:s}".format(ref_class))
-                references.append("('{0:s}',{1:s})".format(n,dt))
+                references.append("('{0:s}',{1:s})".format(n, dt))
 
-        cls_refs = "\tclass_references=[\n" 
+        cls_refs = "\tclass_references=[\n"
         if len(references) > 0:
             i = 0
             for r in references:
@@ -225,11 +251,11 @@ class MyPyRenderer(ObjRenderer):
         else:
             cls_refs = "\tclass_references=[])\n"
         s += cls_refs
- 
+
         s += "\n\n"
         s += "__{0:s}Buffer = _buffer_class_factory(\n".format(k.name)
         s += "\t'__{0:s}Buffer', \n".format(k.name)
-        s += cls_attrs
+        s += cls_props
         s += cls_refs
         s += "\n\n"
         s += "class {0:s}Buffer(__{0:s}Buffer):\n".format(k.name)
@@ -237,7 +263,7 @@ class MyPyRenderer(ObjRenderer):
         s += "\n\n"
         s += "class _{0:s}(__{0:s}):\n\t'''\n\t'''\n".format(k.name)
         d['code'] = s
-        d['dependencies'] = dependencies 
+        d['dependencies'] = dependencies
         return d
 
     def tree_build(self, fh, key):
@@ -256,7 +282,7 @@ class MyPyRenderer(ObjRenderer):
 
         for cl in self.to_build[key]['dependencies']:
             if cl not in self.built:
-                self.tree_build(fh,cl)
+                self.tree_build(fh, cl)
         fh.write(self.to_build[key]['code'])
         self.built.append(key)
 
@@ -273,10 +299,11 @@ class MyPyRenderer(ObjRenderer):
         return s
 
     def end_render(self):
-        f = open(self.filename,'w')
+        f = open(self.filename, 'w')
         f.write(self.header())
         for sk in self.klasses.keys():
-            self.to_build["_{:s}".format(sk)] = self.build_classes(self.klasses[sk])
+            self.to_build["_{:s}".format(sk)] = \
+                    self.build_classes(self.klasses[sk])
         for k in self.to_build.keys():
             self.tree_build(f, k)
         f.write(self.footer())
@@ -285,7 +312,6 @@ class MyPyRenderer(ObjRenderer):
         self.built = []
         ObjRenderer.end_render(self)
 
-dia.register_export ("Gas chemistry code generation (Python)", "py", MyPyRenderer())
 
-
-
+dia.register_export("Gas chemistry code generation (Python)", "py",
+                    MyPyRenderer())

--- a/src/spectroscopy/class_factory.py
+++ b/src/spectroscopy/class_factory.py
@@ -1,10 +1,6 @@
 """
 Generate classes defined in the datamodel.
 """
-from __future__ import print_function
-from builtins import str
-from builtins import range
-from builtins import object
 import collections
 from copy import deepcopy
 import datetime

--- a/src/spectroscopy/datamodel.py
+++ b/src/spectroscopy/datamodel.py
@@ -1,23 +1,31 @@
 import numpy as np
 import datetime
-from spectroscopy.class_factory import _class_factory
+from spectroscopy.class_factory import _base_class_factory, _buffer_class_factory
 
 
-__Instrument = _class_factory('__Instrument', 'base',
+__Instrument = _base_class_factory('__Instrument', 'base',
 	class_attributes=[
 		('tags',(set,)),
-		('name',(np.bytes_,)),
-		('sensor_id',(np.bytes_,)),
-		('location',(np.bytes_,)),
+		('name',(np.str_,)),
+		('sensor_id',(np.str_,)),
+		('location',(np.str_,)),
 		('no_bits',(np.int_,)),
-		('type',(np.bytes_,)),
-		('description',(np.bytes_,))],
+		('type',(np.str_,)),
+		('description',(np.str_,))],
 	class_references=[])
 
 
-__InstrumentBuffer = _class_factory(
-	'__InstrumentBuffer', 'buffer',
-	__Instrument._properties, __Instrument._references)
+__InstrumentBuffer = _buffer_class_factory(
+	'__InstrumentBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('name',(np.str_,)),
+		('sensor_id',(np.str_,)),
+		('location',(np.str_,)),
+		('no_bits',(np.int_,)),
+		('type',(np.str_,)),
+		('description',(np.str_,))],
+	class_references=[])
 
 
 class InstrumentBuffer(__InstrumentBuffer):
@@ -46,20 +54,27 @@ class _Instrument(__Instrument):
 	'''
 
 
-__Target = _class_factory('__Target', 'base',
+__Target = _base_class_factory('__Target', 'base',
 	class_attributes=[
 		('tags',(set,)),
-		('target_id',(np.bytes_,)),
-		('name',(np.bytes_,)),
+		('target_id',(np.str_,)),
+		('name',(np.str_,)),
 		('position',(np.ndarray, np.float_)),
 		('position_error',(np.ndarray, np.float_)),
-		('description',(np.bytes_,))],
+		('description',(np.str_,))],
 	class_references=[])
 
 
-__TargetBuffer = _class_factory(
-	'__TargetBuffer', 'buffer',
-	__Target._properties, __Target._references)
+__TargetBuffer = _buffer_class_factory(
+	'__TargetBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('target_id',(np.str_,)),
+		('name',(np.str_,)),
+		('position',(np.ndarray, np.float_)),
+		('position_error',(np.ndarray, np.float_)),
+		('description',(np.str_,))],
+	class_references=[])
 
 
 class TargetBuffer(__TargetBuffer):
@@ -86,19 +101,25 @@ class _Target(__Target):
 	'''
 
 
-__RawDataType = _class_factory('__RawDataType', 'base',
+__RawDataType = _base_class_factory('__RawDataType', 'base',
 	class_attributes=[
 		('tags',(set,)),
-		('d_var_unit',(np.bytes_,)),
-		('ind_var_unit',(np.bytes_,)),
-		('name',(np.bytes_,)),
-		('acquisition',(np.bytes_,))],
+		('d_var_unit',(np.str_,)),
+		('ind_var_unit',(np.str_,)),
+		('name',(np.str_,)),
+		('acquisition',(np.str_,))],
 	class_references=[])
 
 
-__RawDataTypeBuffer = _class_factory(
-	'__RawDataTypeBuffer', 'buffer',
-	__RawDataType._properties, __RawDataType._references)
+__RawDataTypeBuffer = _buffer_class_factory(
+	'__RawDataTypeBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('d_var_unit',(np.str_,)),
+		('ind_var_unit',(np.str_,)),
+		('name',(np.str_,)),
+		('acquisition',(np.str_,))],
+	class_references=[])
 
 
 class RawDataTypeBuffer(__RawDataTypeBuffer):
@@ -122,17 +143,21 @@ class _RawDataType(__RawDataType):
 	'''
 
 
-__DataQualityType = _class_factory('__DataQualityType', 'base',
+__DataQualityType = _base_class_factory('__DataQualityType', 'base',
 	class_attributes=[
 		('tags',(set,)),
-		('name',(np.bytes_,)),
-		('reference',(np.bytes_,))],
+		('name',(np.str_,)),
+		('reference',(np.str_,))],
 	class_references=[])
 
 
-__DataQualityTypeBuffer = _class_factory(
-	'__DataQualityTypeBuffer', 'buffer',
-	__DataQualityType._properties, __DataQualityType._references)
+__DataQualityTypeBuffer = _buffer_class_factory(
+	'__DataQualityTypeBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('name',(np.str_,)),
+		('reference',(np.str_,))],
+	class_references=[])
 
 
 class DataQualityTypeBuffer(__DataQualityTypeBuffer):
@@ -152,7 +177,7 @@ class _DataQualityType(__DataQualityType):
 	'''
 
 
-__RawData = _class_factory('__RawData', 'extendable',
+__RawData = _base_class_factory('__RawData', 'extendable',
 	class_attributes=[
 		('tags',(set,)),
 		('inc_angle',(np.ndarray, np.float_)),
@@ -170,7 +195,7 @@ __RawData = _class_factory('__RawData', 'extendable',
 		('integration_time',(np.ndarray, np.float_)),
 		('no_averages',(np.float_,)),
 		('temperature',(np.float_,)),
-		('user_notes',(np.bytes_,))],
+		('user_notes',(np.str_,))],
 	class_references=[
 		('instrument',(_Instrument,)),
 		('target',(_Target,)),
@@ -178,9 +203,31 @@ __RawData = _class_factory('__RawData', 'extendable',
 		('data_quality_type',(np.ndarray, _DataQualityType))])
 
 
-__RawDataBuffer = _class_factory(
-	'__RawDataBuffer', 'buffer',
-	__RawData._properties, __RawData._references)
+__RawDataBuffer = _buffer_class_factory(
+	'__RawDataBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('inc_angle',(np.ndarray, np.float_)),
+		('inc_angle_error',(np.ndarray, np.float_)),
+		('bearing',(np.ndarray, np.float_)),
+		('bearing_error',(np.ndarray, np.float_)),
+		('position',(np.ndarray, np.float_)),
+		('position_error',(np.ndarray, np.float_)),
+		('path_length',(np.ndarray, np.float_)),
+		('path_length_error',(np.ndarray, np.float_)),
+		('d_var',(np.ndarray, np.float_)),
+		('ind_var',(np.ndarray, np.float_)),
+		('datetime',(np.ndarray, datetime.datetime)),
+		('data_quality',(np.ndarray, np.float_)),
+		('integration_time',(np.ndarray, np.float_)),
+		('no_averages',(np.float_,)),
+		('temperature',(np.float_,)),
+		('user_notes',(np.str_,))],
+	class_references=[
+		('instrument',(_Instrument,)),
+		('target',(_Target,)),
+		('type',(_RawDataType,)),
+		('data_quality_type',(np.ndarray, _DataQualityType))])
 
 
 class RawDataBuffer(__RawDataBuffer):
@@ -237,19 +284,25 @@ class _RawData(__RawData):
 	'''
 
 
-__Method = _class_factory('__Method', 'extendable',
+__Method = _base_class_factory('__Method', 'extendable',
 	class_attributes=[
 		('tags',(set,)),
-		('name',(np.bytes_,)),
-		('description',(np.bytes_,)),
-		('settings',(np.bytes_,)),
-		('reference',(np.bytes_,))],
+		('name',(np.str_,)),
+		('description',(np.str_,)),
+		('settings',(np.str_,)),
+		('reference',(np.str_,))],
 	class_references=[])
 
 
-__MethodBuffer = _class_factory(
-	'__MethodBuffer', 'buffer',
-	__Method._properties, __Method._references)
+__MethodBuffer = _buffer_class_factory(
+	'__MethodBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('name',(np.str_,)),
+		('description',(np.str_,)),
+		('settings',(np.str_,)),
+		('reference',(np.str_,))],
+	class_references=[])
 
 
 class MethodBuffer(__MethodBuffer):
@@ -273,7 +326,7 @@ class _Method(__Method):
 	'''
 
 
-__GasFlow = _class_factory('__GasFlow', 'base',
+__GasFlow = _base_class_factory('__GasFlow', 'base',
 	class_attributes=[
 		('tags',(set,)),
 		('vx',(np.ndarray, np.float_)),
@@ -282,7 +335,7 @@ __GasFlow = _class_factory('__GasFlow', 'base',
 		('vy_error',(np.ndarray, np.float_)),
 		('vz',(np.ndarray, np.float_)),
 		('vz_error',(np.ndarray, np.float_)),
-		('unit',(np.bytes_,)),
+		('unit',(np.str_,)),
 		('position',(np.ndarray, np.float_)),
 		('position_error',(np.ndarray, np.float_)),
 		('grid_bearing',(np.float_,)),
@@ -290,14 +343,32 @@ __GasFlow = _class_factory('__GasFlow', 'base',
 		('pressure',(np.float_,)),
 		('temperature',(np.float_,)),
 		('datetime',(np.ndarray, datetime.datetime)),
-		('user_notes',(np.bytes_,))],
+		('user_notes',(np.str_,))],
 	class_references=[
 		('methods',(np.ndarray, _Method))])
 
 
-__GasFlowBuffer = _class_factory(
-	'__GasFlowBuffer', 'buffer',
-	__GasFlow._properties, __GasFlow._references)
+__GasFlowBuffer = _buffer_class_factory(
+	'__GasFlowBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('vx',(np.ndarray, np.float_)),
+		('vx_error',(np.ndarray, np.float_)),
+		('vy',(np.ndarray, np.float_)),
+		('vy_error',(np.ndarray, np.float_)),
+		('vz',(np.ndarray, np.float_)),
+		('vz_error',(np.ndarray, np.float_)),
+		('unit',(np.str_,)),
+		('position',(np.ndarray, np.float_)),
+		('position_error',(np.ndarray, np.float_)),
+		('grid_bearing',(np.float_,)),
+		('grid_increments',(np.ndarray, np.float_)),
+		('pressure',(np.float_,)),
+		('temperature',(np.float_,)),
+		('datetime',(np.ndarray, datetime.datetime)),
+		('user_notes',(np.str_,))],
+	class_references=[
+		('methods',(np.ndarray, _Method))])
 
 
 class GasFlowBuffer(__GasFlowBuffer):
@@ -345,26 +416,39 @@ class _GasFlow(__GasFlow):
 	'''
 
 
-__Concentration = _class_factory('__Concentration', 'extendable',
+__Concentration = _base_class_factory('__Concentration', 'extendable',
 	class_attributes=[
 		('tags',(set,)),
 		('rawdata_indices',(np.ndarray, np.int_)),
-		('gas_species',(np.bytes_,)),
+		('gas_species',(np.str_,)),
 		('value',(np.ndarray, np.float_)),
 		('value_error',(np.ndarray, np.float_)),
-		('unit',(np.bytes_,)),
+		('unit',(np.str_,)),
 		('datetime',(np.ndarray, datetime.datetime)),
-		('analyst_contact',(np.bytes_,)),
-		('user_notes',(np.bytes_,))],
+		('analyst_contact',(np.str_,)),
+		('user_notes',(np.str_,))],
 	class_references=[
 		('method',(_Method,)),
 		('gasflow',(_GasFlow,)),
 		('rawdata',(np.ndarray, _RawData))])
 
 
-__ConcentrationBuffer = _class_factory(
-	'__ConcentrationBuffer', 'buffer',
-	__Concentration._properties, __Concentration._references)
+__ConcentrationBuffer = _buffer_class_factory(
+	'__ConcentrationBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('rawdata_indices',(np.ndarray, np.int_)),
+		('gas_species',(np.str_,)),
+		('value',(np.ndarray, np.float_)),
+		('value_error',(np.ndarray, np.float_)),
+		('unit',(np.str_,)),
+		('datetime',(np.ndarray, datetime.datetime)),
+		('analyst_contact',(np.str_,)),
+		('user_notes',(np.str_,))],
+	class_references=[
+		('method',(_Method,)),
+		('gasflow',(_GasFlow,)),
+		('rawdata',(np.ndarray, _RawData))])
 
 
 class ConcentrationBuffer(__ConcentrationBuffer):
@@ -402,25 +486,37 @@ class _Concentration(__Concentration):
 	'''
 
 
-__Flux = _class_factory('__Flux', 'base',
+__Flux = _base_class_factory('__Flux', 'base',
 	class_attributes=[
 		('tags',(set,)),
 		('concentration_indices',(np.ndarray, np.int_)),
 		('value',(np.ndarray, np.float_)),
 		('value_error',(np.ndarray, np.float_)),
 		('datetime',(np.ndarray, datetime.datetime)),
-		('unit',(np.bytes_,)),
-		('analyst_contact',(np.bytes_,)),
-		('user_notes',(np.bytes_,))],
+		('unit',(np.str_,)),
+		('analyst_contact',(np.str_,)),
+		('user_notes',(np.str_,))],
 	class_references=[
 		('method',(_Method,)),
 		('concentration',(_Concentration,)),
 		('gasflow',(_GasFlow,))])
 
 
-__FluxBuffer = _class_factory(
-	'__FluxBuffer', 'buffer',
-	__Flux._properties, __Flux._references)
+__FluxBuffer = _buffer_class_factory(
+	'__FluxBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('concentration_indices',(np.ndarray, np.int_)),
+		('value',(np.ndarray, np.float_)),
+		('value_error',(np.ndarray, np.float_)),
+		('datetime',(np.ndarray, datetime.datetime)),
+		('unit',(np.str_,)),
+		('analyst_contact',(np.str_,)),
+		('user_notes',(np.str_,))],
+	class_references=[
+		('method',(_Method,)),
+		('concentration',(_Concentration,)),
+		('gasflow',(_GasFlow,))])
 
 
 class FluxBuffer(__FluxBuffer):
@@ -456,22 +552,31 @@ class _Flux(__Flux):
 	'''
 
 
-__PreferredFlux = _class_factory('__PreferredFlux', 'base',
+__PreferredFlux = _base_class_factory('__PreferredFlux', 'base',
 	class_attributes=[
 		('tags',(set,)),
 		('flux_indices',(np.ndarray, np.int_)),
 		('datetime',(np.ndarray, datetime.datetime)),
 		('value',(np.ndarray, np.float_)),
 		('value_error',(np.ndarray, np.float_)),
-		('user_notes',(np.bytes_,))],
+		('user_notes',(np.str_,))],
 	class_references=[
 		('fluxes',(np.ndarray, _Flux)),
 		('method_id',(_Method,))])
 
 
-__PreferredFluxBuffer = _class_factory(
-	'__PreferredFluxBuffer', 'buffer',
-	__PreferredFlux._properties, __PreferredFlux._references)
+__PreferredFluxBuffer = _buffer_class_factory(
+	'__PreferredFluxBuffer', 
+	class_attributes=[
+		('tags',(set,)),
+		('flux_indices',(np.ndarray, np.int_)),
+		('datetime',(np.ndarray, datetime.datetime)),
+		('value',(np.ndarray, np.float_)),
+		('value_error',(np.ndarray, np.float_)),
+		('user_notes',(np.str_,))],
+	class_references=[
+		('fluxes',(np.ndarray, _Flux)),
+		('method_id',(_Method,))])
 
 
 class PreferredFluxBuffer(__PreferredFluxBuffer):

--- a/src/spectroscopy/datamodel.py
+++ b/src/spectroscopy/datamodel.py
@@ -6,12 +6,12 @@ from spectroscopy.class_factory import _class_factory
 __Instrument = _class_factory('__Instrument', 'base',
 	class_attributes=[
 		('tags',(set,)),
-		('name',(np.str_,)),
-		('sensor_id',(np.str_,)),
-		('location',(np.str_,)),
+		('name',(np.bytes_,)),
+		('sensor_id',(np.bytes_,)),
+		('location',(np.bytes_,)),
 		('no_bits',(np.int_,)),
-		('type',(np.str_,)),
-		('description',(np.str_,))],
+		('type',(np.bytes_,)),
+		('description',(np.bytes_,))],
 	class_references=[])
 
 
@@ -49,11 +49,11 @@ class _Instrument(__Instrument):
 __Target = _class_factory('__Target', 'base',
 	class_attributes=[
 		('tags',(set,)),
-		('target_id',(np.str_,)),
-		('name',(np.str_,)),
+		('target_id',(np.bytes_,)),
+		('name',(np.bytes_,)),
 		('position',(np.ndarray, np.float_)),
 		('position_error',(np.ndarray, np.float_)),
-		('description',(np.str_,))],
+		('description',(np.bytes_,))],
 	class_references=[])
 
 
@@ -89,10 +89,10 @@ class _Target(__Target):
 __RawDataType = _class_factory('__RawDataType', 'base',
 	class_attributes=[
 		('tags',(set,)),
-		('d_var_unit',(np.str_,)),
-		('ind_var_unit',(np.str_,)),
-		('name',(np.str_,)),
-		('acquisition',(np.str_,))],
+		('d_var_unit',(np.bytes_,)),
+		('ind_var_unit',(np.bytes_,)),
+		('name',(np.bytes_,)),
+		('acquisition',(np.bytes_,))],
 	class_references=[])
 
 
@@ -125,8 +125,8 @@ class _RawDataType(__RawDataType):
 __DataQualityType = _class_factory('__DataQualityType', 'base',
 	class_attributes=[
 		('tags',(set,)),
-		('name',(np.str_,)),
-		('reference',(np.str_,))],
+		('name',(np.bytes_,)),
+		('reference',(np.bytes_,))],
 	class_references=[])
 
 
@@ -170,7 +170,7 @@ __RawData = _class_factory('__RawData', 'extendable',
 		('integration_time',(np.ndarray, np.float_)),
 		('no_averages',(np.float_,)),
 		('temperature',(np.float_,)),
-		('user_notes',(np.str_,))],
+		('user_notes',(np.bytes_,))],
 	class_references=[
 		('instrument',(_Instrument,)),
 		('target',(_Target,)),
@@ -240,10 +240,10 @@ class _RawData(__RawData):
 __Method = _class_factory('__Method', 'extendable',
 	class_attributes=[
 		('tags',(set,)),
-		('name',(np.str_,)),
-		('description',(np.str_,)),
-		('settings',(np.str_,)),
-		('reference',(np.str_,))],
+		('name',(np.bytes_,)),
+		('description',(np.bytes_,)),
+		('settings',(np.bytes_,)),
+		('reference',(np.bytes_,))],
 	class_references=[])
 
 
@@ -282,7 +282,7 @@ __GasFlow = _class_factory('__GasFlow', 'base',
 		('vy_error',(np.ndarray, np.float_)),
 		('vz',(np.ndarray, np.float_)),
 		('vz_error',(np.ndarray, np.float_)),
-		('unit',(np.str_,)),
+		('unit',(np.bytes_,)),
 		('position',(np.ndarray, np.float_)),
 		('position_error',(np.ndarray, np.float_)),
 		('grid_bearing',(np.float_,)),
@@ -290,7 +290,7 @@ __GasFlow = _class_factory('__GasFlow', 'base',
 		('pressure',(np.float_,)),
 		('temperature',(np.float_,)),
 		('datetime',(np.ndarray, datetime.datetime)),
-		('user_notes',(np.str_,))],
+		('user_notes',(np.bytes_,))],
 	class_references=[
 		('methods',(np.ndarray, _Method))])
 
@@ -349,13 +349,13 @@ __Concentration = _class_factory('__Concentration', 'extendable',
 	class_attributes=[
 		('tags',(set,)),
 		('rawdata_indices',(np.ndarray, np.int_)),
-		('gas_species',(np.str_,)),
+		('gas_species',(np.bytes_,)),
 		('value',(np.ndarray, np.float_)),
 		('value_error',(np.ndarray, np.float_)),
-		('unit',(np.str_,)),
+		('unit',(np.bytes_,)),
 		('datetime',(np.ndarray, datetime.datetime)),
-		('analyst_contact',(np.str_,)),
-		('user_notes',(np.str_,))],
+		('analyst_contact',(np.bytes_,)),
+		('user_notes',(np.bytes_,))],
 	class_references=[
 		('method',(_Method,)),
 		('gasflow',(_GasFlow,)),
@@ -409,9 +409,9 @@ __Flux = _class_factory('__Flux', 'base',
 		('value',(np.ndarray, np.float_)),
 		('value_error',(np.ndarray, np.float_)),
 		('datetime',(np.ndarray, datetime.datetime)),
-		('unit',(np.str_,)),
-		('analyst_contact',(np.str_,)),
-		('user_notes',(np.str_,))],
+		('unit',(np.bytes_,)),
+		('analyst_contact',(np.bytes_,)),
+		('user_notes',(np.bytes_,))],
 	class_references=[
 		('method',(_Method,)),
 		('concentration',(_Concentration,)),
@@ -463,7 +463,7 @@ __PreferredFlux = _class_factory('__PreferredFlux', 'base',
 		('datetime',(np.ndarray, datetime.datetime)),
 		('value',(np.ndarray, np.float_)),
 		('value_error',(np.ndarray, np.float_)),
-		('user_notes',(np.str_,))],
+		('user_notes',(np.bytes_,))],
 	class_references=[
 		('fluxes',(np.ndarray, _Flux)),
 		('method_id',(_Method,))])

--- a/src/spectroscopy/datamodel.py
+++ b/src/spectroscopy/datamodel.py
@@ -4,7 +4,7 @@ from spectroscopy.class_factory import _base_class_factory, _buffer_class_factor
 
 
 __Instrument = _base_class_factory('__Instrument', 'base',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('name',(np.str_,)),
 		('sensor_id',(np.str_,)),
@@ -17,7 +17,7 @@ __Instrument = _base_class_factory('__Instrument', 'base',
 
 __InstrumentBuffer = _buffer_class_factory(
 	'__InstrumentBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('name',(np.str_,)),
 		('sensor_id',(np.str_,)),
@@ -55,7 +55,7 @@ class _Instrument(__Instrument):
 
 
 __Target = _base_class_factory('__Target', 'base',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('target_id',(np.str_,)),
 		('name',(np.str_,)),
@@ -67,7 +67,7 @@ __Target = _base_class_factory('__Target', 'base',
 
 __TargetBuffer = _buffer_class_factory(
 	'__TargetBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('target_id',(np.str_,)),
 		('name',(np.str_,)),
@@ -102,7 +102,7 @@ class _Target(__Target):
 
 
 __RawDataType = _base_class_factory('__RawDataType', 'base',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('d_var_unit',(np.str_,)),
 		('ind_var_unit',(np.str_,)),
@@ -113,7 +113,7 @@ __RawDataType = _base_class_factory('__RawDataType', 'base',
 
 __RawDataTypeBuffer = _buffer_class_factory(
 	'__RawDataTypeBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('d_var_unit',(np.str_,)),
 		('ind_var_unit',(np.str_,)),
@@ -144,7 +144,7 @@ class _RawDataType(__RawDataType):
 
 
 __DataQualityType = _base_class_factory('__DataQualityType', 'base',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('name',(np.str_,)),
 		('reference',(np.str_,))],
@@ -153,7 +153,7 @@ __DataQualityType = _base_class_factory('__DataQualityType', 'base',
 
 __DataQualityTypeBuffer = _buffer_class_factory(
 	'__DataQualityTypeBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('name',(np.str_,)),
 		('reference',(np.str_,))],
@@ -178,7 +178,7 @@ class _DataQualityType(__DataQualityType):
 
 
 __RawData = _base_class_factory('__RawData', 'extendable',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('inc_angle',(np.ndarray, np.float_)),
 		('inc_angle_error',(np.ndarray, np.float_)),
@@ -205,7 +205,7 @@ __RawData = _base_class_factory('__RawData', 'extendable',
 
 __RawDataBuffer = _buffer_class_factory(
 	'__RawDataBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('inc_angle',(np.ndarray, np.float_)),
 		('inc_angle_error',(np.ndarray, np.float_)),
@@ -285,7 +285,7 @@ class _RawData(__RawData):
 
 
 __Method = _base_class_factory('__Method', 'extendable',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('name',(np.str_,)),
 		('description',(np.str_,)),
@@ -296,7 +296,7 @@ __Method = _base_class_factory('__Method', 'extendable',
 
 __MethodBuffer = _buffer_class_factory(
 	'__MethodBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('name',(np.str_,)),
 		('description',(np.str_,)),
@@ -327,7 +327,7 @@ class _Method(__Method):
 
 
 __GasFlow = _base_class_factory('__GasFlow', 'base',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('vx',(np.ndarray, np.float_)),
 		('vx_error',(np.ndarray, np.float_)),
@@ -350,7 +350,7 @@ __GasFlow = _base_class_factory('__GasFlow', 'base',
 
 __GasFlowBuffer = _buffer_class_factory(
 	'__GasFlowBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('vx',(np.ndarray, np.float_)),
 		('vx_error',(np.ndarray, np.float_)),
@@ -417,7 +417,7 @@ class _GasFlow(__GasFlow):
 
 
 __Concentration = _base_class_factory('__Concentration', 'extendable',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('rawdata_indices',(np.ndarray, np.int_)),
 		('gas_species',(np.str_,)),
@@ -435,7 +435,7 @@ __Concentration = _base_class_factory('__Concentration', 'extendable',
 
 __ConcentrationBuffer = _buffer_class_factory(
 	'__ConcentrationBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('rawdata_indices',(np.ndarray, np.int_)),
 		('gas_species',(np.str_,)),
@@ -487,7 +487,7 @@ class _Concentration(__Concentration):
 
 
 __Flux = _base_class_factory('__Flux', 'base',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('concentration_indices',(np.ndarray, np.int_)),
 		('value',(np.ndarray, np.float_)),
@@ -504,7 +504,7 @@ __Flux = _base_class_factory('__Flux', 'base',
 
 __FluxBuffer = _buffer_class_factory(
 	'__FluxBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('concentration_indices',(np.ndarray, np.int_)),
 		('value',(np.ndarray, np.float_)),
@@ -553,7 +553,7 @@ class _Flux(__Flux):
 
 
 __PreferredFlux = _base_class_factory('__PreferredFlux', 'base',
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('flux_indices',(np.ndarray, np.int_)),
 		('datetime',(np.ndarray, datetime.datetime)),
@@ -567,7 +567,7 @@ __PreferredFlux = _base_class_factory('__PreferredFlux', 'base',
 
 __PreferredFluxBuffer = _buffer_class_factory(
 	'__PreferredFluxBuffer', 
-	class_attributes=[
+	class_properties=[
 		('tags',(set,)),
 		('flux_indices',(np.ndarray, np.int_)),
 		('datetime',(np.ndarray, datetime.datetime)),

--- a/src/spectroscopy/dataset.py
+++ b/src/spectroscopy/dataset.py
@@ -1,9 +1,6 @@
 """
 Provide container class for gas chemistry data.
 """
-from future.utils import native
-from builtins import str
-from builtins import object
 import hashlib
 import warnings
 
@@ -110,7 +107,7 @@ class Dataset(object):
                 # The group does not exist. Create it.
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore')
-                    group2 = self._f.create_group(group, native(nodename),
+                    group2 = self._f.create_group(group, nodename,
                                                   title=title,
                                                   filters=filters)
             group = group2
@@ -175,7 +172,7 @@ class Dataset(object):
             pass
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            group = self._f.create_group('/'+group_name, native(str(rid)))
+            group = self._f.create_group('/'+group_name, str(rid))
         e = _C(group, data_buffer, pedantic=pedantic)
         self.elements[group_name].append(e)
         return e

--- a/src/spectroscopy/plugins/flyspec.py
+++ b/src/spectroscopy/plugins/flyspec.py
@@ -1,6 +1,10 @@
 """
 Plugin to read FlySpec data.
 """
+from __future__ import division
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import datetime
 import os
 import struct
@@ -53,11 +57,11 @@ class FlySpecPlugin(DatasetPluginBase):
             Convert degrees and decimal minutes to decimal degrees.
             """
             idx = x.find('.')
-            minutes = float(x[idx - 2:]) / 60.
+            minutes = old_div(float(x[idx - 2:]), 60.)
             deg = float(x[:idx - 2])
             return deg + minutes
 
-        data = np.loadtxt(filename, usecols=range(0, 21),
+        data = np.loadtxt(filename, usecols=list(range(0, 21)),
                           converters={
                               8: todd,
                               9: lambda x: -1.0 if x.lower() == 's' else 1.0,

--- a/src/spectroscopy/plugins/flyspec.py
+++ b/src/spectroscopy/plugins/flyspec.py
@@ -1,11 +1,7 @@
 """
 Plugin to read FlySpec data.
 """
-from __future__ import division
-from builtins import str
-from builtins import range
 from functools import partial
-from past.utils import old_div
 import datetime
 import os
 import struct
@@ -59,7 +55,7 @@ class FlySpecPlugin(DatasetPluginBase):
             """
             xx = x.decode('ascii')
             idx = xx.find('.')
-            minutes = old_div(float(xx[idx - 2:]), 60.)
+            minutes = float(xx[idx - 2:]) / 60.
             deg = float(xx[:idx - 2])
             return deg + minutes
 
@@ -184,7 +180,7 @@ class FlySpecRefPlugin(DatasetPluginBase):
         i = 0
         counts = []
         while i < len(raw_data):
-            counts.append(struct.unpack("2048f",raw_data[i:i+(2048 * 4)]))
+            counts.append(struct.unpack("2048f", raw_data[i:i+(2048 * 4)]))
             i += (2048 * 4)
         return counts
 
@@ -196,14 +192,17 @@ class FlySpecRefPlugin(DatasetPluginBase):
             wavelengths = kargs['wavelengths']
             mtype = kargs['type']
         except KeyError:
-            raise FlySpecPluginException('Please provide wavelengths and measurement type.')
-        
+            msg = 'Please provide wavelengths and measurement type.'
+            raise FlySpecPluginException(msg)
+
         spectra = np.array(self._read_spectra(filename))
         if spectra.shape[1] != wavelengths.size:
-            raise FlySpecPluginException("Spectra and wavelengths don't have the same size.")
+            msg = "Spectra and wavelengths don't have the same size."
+            raise FlySpecPluginException(msg)
         rb = RawDataBuffer(ind_var=wavelengths, d_var=spectra)
-        rdtb = RawDataTypeBuffer(d_var_unit='ppm m', ind_var_unit='nm', name=mtype)
-        return {str(rb):rb, str(rdtb):rdtb}
+        rdtb = RawDataTypeBuffer(d_var_unit='ppm m', ind_var_unit='nm',
+                                 name=mtype)
+        return {str(rb): rb, str(rdtb): rdtb}
 
     def close(self, filename):
         raise Exception('Close is undefined for the FlySpecRef backend')
@@ -214,20 +213,21 @@ class FlySpecRefPlugin(DatasetPluginBase):
 
 
 class FlySpecWindPlugin(DatasetPluginBase):
-    
+
     def read(self, dataset, filename, timeshift=0, **kargs):
         """
         Read the wind data for the Flyspecs on Tongariro.
         """
-        data = np.loadtxt(filename, dtype={'names':('date', 'wd', 'ws'), 
-                                           'formats':('S19', np.float, np.float)})
+        data = np.loadtxt(filename, dtype={'names': ('date', 'wd', 'ws'),
+                                           'formats': ('S19', np.float,
+                                                       np.float)})
 
         npts = data.shape[0]
-        position = np.tile(np.array([175.673, -39.108, 0.0]), (npts, 1)) 
+        position = np.tile(np.array([175.673, -39.108, 0.0]), (npts, 1))
         vx = np.zeros(npts)
         vy = np.zeros(npts)
         vz = np.zeros(npts)
-        time = np.empty(npts,dtype='S19')
+        time = np.empty(npts, dtype='S19')
         for i in range(npts):
             ws = data['ws'][i]
             wd = data['wd'][i]
@@ -240,7 +240,7 @@ class FlySpecWindPlugin(DatasetPluginBase):
             vx[i] = _vx
             vy[i] = _vy
             vz[i] = np.nan
-            time[i] = date 
+            time[i] = date
 
         dt = time.astype('datetime64[us]')
         ts = np.timedelta64(int(timeshift), 'h')
@@ -251,7 +251,7 @@ class FlySpecWindPlugin(DatasetPluginBase):
         mb = MethodBuffer(name='some model')
         m = dataset.new(mb)
         gfb = GasFlowBuffer(methods=[m], vx=vx, vy=vy, vz=vz,
-                            position=position, datetime=dt.astype(str), 
+                            position=position, datetime=dt.astype(str),
                             user_notes=description, unit='m/s')
         gf = dataset.new(gfb)
         return gf
@@ -259,6 +259,7 @@ class FlySpecWindPlugin(DatasetPluginBase):
     @staticmethod
     def get_format():
         return 'flyspecwind'
+
 
 if __name__ == '__main__':
     import doctest

--- a/src/spectroscopy/plugins/minidoas.py
+++ b/src/spectroscopy/plugins/minidoas.py
@@ -181,13 +181,13 @@ class MiniDoasScan(DatasetPluginBase):
         def dateconverter(x):
             return date+'T'+x.decode('ascii')
 
-        dt = np.dtype([('time', 'S19'), ('ws', np.float), ('wd', np.float),
+        dt = np.dtype([('time', 'U19'), ('ws', np.float), ('wd', np.float),
                        ('R2', np.float), ('SO2Start', np.float),
                        ('SO2Max', np.float), ('SO2End', np.float),
                        ('PlumeRange', np.float), ('PlumeWidth', np.float),
                        ('PlumeHeight', np.float), ('Easting', np.float),
                        ('Northing', np.float), ('Track', np.float),
-                       ('Emission', np.float), ('Station', 'S2'),
+                       ('Emission', np.float), ('Station', 'U2'),
                        ('EmissionSE', np.float)])
         try:
             data = np.loadtxt(filename, delimiter=',', skiprows=1, dtype=dt,

--- a/src/spectroscopy/plugins/minidoas.py
+++ b/src/spectroscopy/plugins/minidoas.py
@@ -1,10 +1,6 @@
 """
 Plugin to read MiniDOAS data.
 """
-from __future__ import division
-from builtins import zip
-from builtins import str
-from past.utils import old_div
 import codecs
 import datetime
 import io
@@ -74,8 +70,8 @@ class MiniDoasRaw(DatasetPluginBase):
         fh.close()
         # Construct datetimes
         date = data['date'].astype('datetime64')
-        hours = (old_div(data['time'],3600.)).astype(int)
-        minutes = (old_div((data['time'] - hours*3600.),60.)).astype(int)
+        hours = (data['time']/3600.).astype(int)
+        minutes = ((data['time'] - hours*3600.)/60.).astype(int)
         fseconds = data['time'] - hours*3600. - minutes*60.
         iseconds = (fseconds).astype(int)
         mseconds = np.round((fseconds - iseconds), 3)*1e3
@@ -154,9 +150,9 @@ class MiniDoasScan(DatasetPluginBase):
         for _ws, h, w, e, n, t, dt in zip(ws, pheight, pwidth, peasting,
                                           pnorthing, ptrack, datetime):
             lon, lat = pyproj.transform(self.srcp, self.destp, e, n)
-            position.append([lon, lat, h-old_div(w,2.)])
+            position.append([lon, lat, h-w/2.])
             position.append([lon, lat, h])
-            position.append([lon, lat, h+old_div(w,2.)])
+            position.append([lon, lat, h+w/2.])
             time.extend([dt]*3)
             x, y = bearing2vec(t, _ws)
             vx.extend([x]*3)
@@ -178,6 +174,7 @@ class MiniDoasScan(DatasetPluginBase):
             raise MiniDoasException("'date' unspecified.")
 
         station = kargs.get('station', None)
+
         def dateconverter(x):
             return date+'T'+x.decode('ascii')
 
@@ -207,8 +204,8 @@ class MiniDoasScan(DatasetPluginBase):
             idx = np.arange(data.shape[0])
         dtm = data['time'][idx].astype('datetime64[s]')
         dtm -= np.timedelta64(int(timeshift), 'h')
-        fb = FluxBuffer(value=old_div(data['Emission'][idx],86.4),
-                        value_error=old_div(data['EmissionSE'][idx],86.4),
+        fb = FluxBuffer(value=data['Emission'][idx]/86.4,
+                        value_error=data['EmissionSE'][idx]/86.4,
                         datetime=dtm.astype(str))
         mb, gfb = self._plumegeometry2gasflow(data['ws'][idx],
                                               data['PlumeHeight'][idx],

--- a/src/spectroscopy/plugins/nzmetservice.py
+++ b/src/spectroscopy/plugins/nzmetservice.py
@@ -1,9 +1,6 @@
 """
 Plugin to read and write FlySpec data.
 """
-from builtins import zip
-from builtins import map
-from builtins import range
 from collections import defaultdict
 import datetime
 import os

--- a/src/spectroscopy/plugins/nzmetservice.py
+++ b/src/spectroscopy/plugins/nzmetservice.py
@@ -160,7 +160,7 @@ class NZMetservicePlugin(DatasetPluginBase):
         vy = np.zeros(npts)
         vz = np.zeros(npts)
         position = np.zeros((npts, 3))
-        time = np.empty(npts, dtype='S26')
+        time = np.empty(npts, dtype='U26')
         for _i, _e in enumerate(_mdls[_mod]):
             t, lon, lat, h, d, s = _e
             # if windspeed is 0 give it a tiny value

--- a/src/spectroscopy/plugins/nzmetservice.py
+++ b/src/spectroscopy/plugins/nzmetservice.py
@@ -1,6 +1,9 @@
 """
 Plugin to read and write FlySpec data.
 """
+from builtins import zip
+from builtins import map
+from builtins import range
 from collections import defaultdict
 import datetime
 import os
@@ -62,7 +65,7 @@ class NZMetservicePlugin(DatasetPluginBase):
             for _i, _e in enumerate(_a[1:]):
                 if _e == '-':
                     continue
-                d, s = map(float, _e.split('/'))
+                d, s = list(map(float, _e.split('/')))
                 vals.append((times[_i], self.volc_dict[md][0],
                              self.volc_dict[md][1], _h, d, s * 0.514444))
         return vals

--- a/src/spectroscopy/util.py
+++ b/src/spectroscopy/util.py
@@ -184,6 +184,8 @@ def get_wind_speed(gf, lon, lat, elev, date):
     else:
         _d = date
     _ts = calendar.timegm((_d.utctimetuple()))
+    # convert to ms
+    _ts *= 1e3
     _dt = gf.datetime[:].astype(np.datetime64)
     # find nearest point
     _t = np.atleast_2d(_dt).T
@@ -200,7 +202,7 @@ def get_wind_speed(gf, lon, lat, elev, date):
         vx_error = gf.vx_error[:][ndx[0]]
         vy_error = gf.vy_error[:][ndx[0]]
         vz_error = gf.vz_error[:][ndx[0]]
-    except AttributeError:
+    except TypeError:
         vx_error = None
         vy_error = None
         vz_error = None

--- a/src/spectroscopy/visualize.py
+++ b/src/spectroscopy/visualize.py
@@ -1,12 +1,6 @@
 """
 Overview plots for different elements in a dataset.
 """
-from __future__ import division
-
-from builtins import zip
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.colors import Normalize, LogNorm
@@ -136,11 +130,11 @@ def plot_rawdata(r, savefig=None, **kargs):
     cax, kw = matplotlib.colorbar.make_axes(plt.gca())
     norm = Normalize(vmin=0, vmax=nc, clip=False)
     c = matplotlib.colorbar.ColorbarBase(cax, cmap='RdBu', norm=norm)
-    ticks = np.array([0, int(old_div(nc,2.)), nc-1])
+    ticks = np.array([0, int(nc/2.), nc-1])
     c.set_ticks(ticks)
     try:
         times = r.datetime[idx]
-        labels = np.array([times[0], times[int(old_div(nc,2.))], times[nc-1]])
+        labels = np.array([times[0], times[int(nc/2.)], times[nc-1]])
         c.set_ticklabels(labels)
     except tables.NoSuchNodeError:
         pass

--- a/src/spectroscopy/visualize.py
+++ b/src/spectroscopy/visualize.py
@@ -1,7 +1,12 @@
 """
 Overview plots for different elements in a dataset.
 """
+from __future__ import division
 
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.colors import Normalize, LogNorm
@@ -74,11 +79,11 @@ def plot_concentration(c, savefig=None, angle_bin=1.0, **kargs):
     fig = plt.figure()
     if log:
         z = np.where(m > 0.0, m, 0.1)
-        plt.contourf(range(nretrieval), angle_bins[1:], z.T, ncontours,
+        plt.contourf(list(range(nretrieval)), angle_bins[1:], z.T, ncontours,
                      norm=LogNorm(z.min(), z.max()), cmap=cmap)
     else:
         z = np.ma.masked_invalid(m)
-        plt.contourf(range(nretrieval), angle_bins[1:], m.T, ncontours,
+        plt.contourf(list(range(nretrieval)), angle_bins[1:], m.T, ncontours,
                      norm=Normalize(z.min(), z.max()), cmap=cmap)
     new_labels = []
     new_ticks = []
@@ -131,11 +136,11 @@ def plot_rawdata(r, savefig=None, **kargs):
     cax, kw = matplotlib.colorbar.make_axes(plt.gca())
     norm = Normalize(vmin=0, vmax=nc, clip=False)
     c = matplotlib.colorbar.ColorbarBase(cax, cmap='RdBu', norm=norm)
-    ticks = np.array([0, int(nc/2.), nc-1])
+    ticks = np.array([0, int(old_div(nc,2.)), nc-1])
     c.set_ticks(ticks)
     try:
         times = r.datetime[idx]
-        labels = np.array([times[0], times[int(nc/2.)], times[nc-1]])
+        labels = np.array([times[0], times[int(old_div(nc,2.))], times[nc-1]])
         c.set_ticklabels(labels)
     except tables.NoSuchNodeError:
         pass

--- a/tests/runall.sh
+++ b/tests/runall.sh
@@ -5,7 +5,7 @@
 # Y. Behr 10/17      #
 ######################
 
-python2 -m unittest discover -v
-python2 verify_all_nzmetservice_data.py ./data
+python -m unittest discover -v
+python verify_all_nzmetservice_data.py ./data
 
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1,14 +1,20 @@
+import datetime
 import tempfile
 import unittest
 import warnings
 
 import numpy as np
+import tables
 
 from spectroscopy.datamodel import (RawDataBuffer, TargetBuffer,
                                     InstrumentBuffer, RawDataTypeBuffer,
                                     GasFlowBuffer, PreferredFluxBuffer,
-                                    MethodBuffer)
+                                    MethodBuffer, _Instrument, _Target,
+                                    _DataQualityType, _RawDataType)
 from spectroscopy.dataset import Dataset
+from spectroscopy.class_factory import (_buffer_class_factory,
+                                        _base_class_factory,
+                                        ResourceIdentifier)
 
 
 class DatamodelTestCase(unittest.TestCase):
@@ -82,7 +88,7 @@ class DatamodelTestCase(unittest.TestCase):
                            ind_var=np.arange(2048),
                            datetime=['2017-01-10T15:23:00'])
         r = d.new(rb)
-        self.assertEqual(r.target.target_id[:], 'WI001')
+        self.assertEqual(r.target.target_id[0], 'WI001')
 
     def test_repr(self):
         d = Dataset(tempfile.mktemp(), 'w')
@@ -96,7 +102,9 @@ class DatamodelTestCase(unittest.TestCase):
                        '2017', 'target_id:', 'WI001', 'name:', 'White',
                        'Island', 'main', 'vent', 'Created']
         # remove ID and creation time from test as they always change
-        self.assertEqual(str(repr(t)).split()[2:-2], test_string)
+        repr_string = str(repr(t)).split()[2:-2]
+        for e in repr_string: 
+            self.assertTrue(e in test_string)
 
     def test_sum(self):
         d1 = Dataset(tempfile.mktemp(), 'w')
@@ -280,7 +288,7 @@ class DatamodelTestCase(unittest.TestCase):
 
         d1 = Dataset.open(fn)
         r1 = d1.elements['RawData'][0]
-        self.assertEqual(r1.target.name[:][0], 'White Island main vent')
+        self.assertEqual(r1.target.name[0], 'White Island main vent')
         self.assertEqual(list(r1.instrument.tags)[0], 'MD01')
 
     def test_tagging(self):
@@ -393,6 +401,148 @@ class DatamodelTestCase(unittest.TestCase):
 
         e = d.select("type.acquisition == 'stationary'", etype='RawData')
         self.assertEqual(e['RawData'][0], r)
+
+    def test_buffer_class_factory(self):
+        cls_attributes = [('tags', (set,)),
+                          ('inc_angle', (np.ndarray, np.float_)),
+                          ('inc_angle_error', (np.ndarray, np.float_)),
+                          ('bearing', (np.ndarray, np.float_)),
+                          ('bearing_error', (np.ndarray, np.float_)),
+                          ('position', (np.ndarray, np.float_)),
+                          ('position_error', (np.ndarray, np.float_)),
+                          ('path_length', (np.ndarray, np.float_)),
+                          ('path_length_error', (np.ndarray, np.float_)),
+                          ('d_var', (np.ndarray, np.float_)),
+                          ('ind_var', (np.ndarray, np.float_)),
+                          ('datetime', (np.ndarray, datetime.datetime)),
+                          ('data_quality', (np.ndarray, np.float_)),
+                          ('integration_time', (np.ndarray, np.float_)),
+                          ('no_averages', (np.float_,)),
+                          ('temperature', (np.float_,)),
+                          ('user_notes', (np.str_,))]
+        cls_references = [('instrument', (_Instrument,)),
+                          ('target', (_Target,)),
+                          ('type', (_RawDataType,)),
+                          ('data_quality_type', (np.ndarray,
+                                                 _DataQualityType))]
+
+        RawDataBuffer = _buffer_class_factory('RawDataBuffer',
+                                              class_attributes=cls_attributes,
+                                              class_references=cls_references)
+        rd = RawDataBuffer(d_var=np.zeros((1, 2048)), ind_var=np.arange(2048),
+                           datetime=['2017-01-10T15:23:00'])
+        self.assertTrue(isinstance(rd.datetime[0], np.datetime64))
+        with self.assertRaises(AttributeError):
+            rd.something = 'something'
+        rd1 = RawDataBuffer(d_var=np.zeros((1, 2048)), ind_var=np.arange(2048))
+        self.assertEqual(rd1.datetime, None)
+        rd1.datetime = ['2017-01-10T15:23:00']
+        self.assertTrue(isinstance(rd1.datetime[0], np.datetime64))
+
+    def test_base_class_factory(self):
+        cls_attr_target = [('tags', (set,)),
+                           ('target_id', (np.str_,)),
+                           ('name', (np.str_,)),
+                           ('position', (np.ndarray, np.float_)),
+                           ('position_error', (np.ndarray, np.float_)),
+                           ('description', (np.str_,))]
+
+        _Target = _base_class_factory('_Target', class_type='base',
+                                      class_attributes=cls_attr_target)
+        cls_attr_dqt = [('tags', (set,)), ('name', (np.str_,)),
+                        ('reference', (np.str_,))]
+
+        _DataQualityType = _base_class_factory('_DataQualityType', 'base',
+                                               class_attributes=cls_attr_dqt)
+
+        cls_attr_rawdt = [('tags', (set,)),
+                          ('inc_angle', (np.ndarray, np.float_)),
+                          ('inc_angle_error', (np.ndarray, np.float_)),
+                          ('bearing', (np.ndarray, np.float_)),
+                          ('bearing_error', (np.ndarray, np.float_)),
+                          ('position', (np.ndarray, np.float_)),
+                          ('position_error', (np.ndarray, np.float_)),
+                          ('path_length', (np.ndarray, np.float_)),
+                          ('path_length_error', (np.ndarray, np.float_)),
+                          ('d_var', (np.ndarray, np.float_)),
+                          ('ind_var', (np.ndarray, np.float_)),
+                          ('datetime', (np.ndarray, datetime.datetime)),
+                          ('data_quality', (np.ndarray, np.float_)),
+                          ('integration_time', (np.ndarray, np.float_)),
+                          ('no_averages', (np.float_,)),
+                          ('temperature', (np.float_,)),
+                          ('user_notes', (np.str_,))]
+        cls_refr_rawdt = [('instrument', (_Instrument,)),
+                          ('target', (_Target,)),
+                          ('type', (_RawDataType,)),
+                          ('data_quality_type', (np.ndarray,
+                                                 _DataQualityType))]
+
+        filename = tempfile.mktemp()
+        h5f = tables.open_file(filename, 'w')
+        h5f.create_earray('/', 'hash', tables.StringAtom(itemsize=28), (0,))
+
+        TargetBuffer = _buffer_class_factory('TargetBuffer',
+                                             class_attributes=cls_attr_target)
+        DataQualityTypeBuffer = \
+                _buffer_class_factory('DataQualityTypeBuffer',
+                                      class_attributes=cls_attr_dqt)
+
+        dtb1 = DataQualityTypeBuffer(name='q-measure 1')
+        dtb2 = DataQualityTypeBuffer(name='q-measure 2')
+
+        tb = TargetBuffer(name='White Island', position=(177.2, -37.5, 50))
+
+        group_name = _Target.__name__.strip('_')
+        h5f.create_group('/', group_name)
+        rid = ResourceIdentifier()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            group = h5f.create_group('/'+group_name, str(rid))
+        t = _Target(group, tb)
+
+        rid = ResourceIdentifier()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            group = h5f.create_group('/'+group_name, str(rid))
+        dt1 = _DataQualityType(group, dtb1)
+
+        rid = ResourceIdentifier()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            group = h5f.create_group('/'+group_name, str(rid))
+        dt2 = _DataQualityType(group, dtb2)
+
+        _RawData = _base_class_factory('_RawData', class_type='base',
+                                       class_attributes=cls_attr_rawdt,
+                                       class_references=cls_refr_rawdt)
+
+        RawDataBuffer = _buffer_class_factory('RawDataBuffer',
+                                              class_attributes=cls_attr_rawdt,
+                                              class_references=cls_refr_rawdt)
+        rdb = RawDataBuffer(d_var=np.zeros((1, 2048)), ind_var=np.arange(2048),
+                            datetime=['2017-01-10T15:23:00'], no_averages=23,
+                            user_notes='something', target=t,
+                            data_quality_type=[dt1, dt2])
+        group_name = _RawData.__name__.strip('_')
+        h5f.create_group('/', group_name)
+        rid = ResourceIdentifier()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            group = h5f.create_group('/'+group_name, str(rid))
+        rd = _RawData(group, rdb)
+        np.testing.assert_array_equal(rd.d_var[:], np.zeros((1, 2048)))
+        with self.assertRaises(AttributeError):
+            rd.something = 'something'
+        with self.assertRaises(AttributeError):
+            rd.d_var = np.ones((1, 2048))
+        self.assertEqual(rd.user_notes, 'something')
+        self.assertEqual(rd.no_averages, 23)
+        np.testing.assert_array_equal(rd.target.position[:],
+                                      np.array([177.2, -37.5, 50.]))
+        self.assertEqual(rd.target.name, 'White Island')
+        self.assertEqual(rd.data_quality_type[1].name, 'q-measure 2')
+        print(repr(rd))
 
 
 def suite():

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -410,7 +410,7 @@ class DatamodelTestCase(unittest.TestCase):
         self.assertEqual(e['RawData'][0], r)
 
     def test_buffer_class_factory(self):
-        cls_attributes = [('tags', (set,)),
+        cls_properties = [('tags', (set,)),
                           ('inc_angle', (np.ndarray, np.float_)),
                           ('inc_angle_error', (np.ndarray, np.float_)),
                           ('bearing', (np.ndarray, np.float_)),
@@ -434,7 +434,7 @@ class DatamodelTestCase(unittest.TestCase):
                                                  _DataQualityType))]
 
         RawDataBuffer = _buffer_class_factory('RawDataBuffer',
-                                              class_attributes=cls_attributes,
+                                              class_properties=cls_properties,
                                               class_references=cls_references)
         rd = RawDataBuffer(d_var=np.zeros((1, 2048)), ind_var=np.arange(2048),
                            datetime=['2017-01-10T15:23:00'])
@@ -447,38 +447,38 @@ class DatamodelTestCase(unittest.TestCase):
         self.assertTrue(isinstance(rd1.datetime[0], np.datetime64))
 
     def test_base_class_factory(self):
-        cls_attr_target = [('tags', (set,)),
-                           ('target_id', (np.str_,)),
-                           ('name', (np.str_,)),
-                           ('position', (np.ndarray, np.float_)),
-                           ('position_error', (np.ndarray, np.float_)),
-                           ('description', (np.str_,))]
+        cls_props_target = [('tags', (set,)),
+                            ('target_id', (np.str_,)),
+                            ('name', (np.str_,)),
+                            ('position', (np.ndarray, np.float_)),
+                            ('position_error', (np.ndarray, np.float_)),
+                            ('description', (np.str_,))]
 
         _Target = _base_class_factory('_Target', class_type='base',
-                                      class_attributes=cls_attr_target)
-        cls_attr_dqt = [('tags', (set,)), ('name', (np.str_,)),
-                        ('reference', (np.str_,))]
+                                      class_properties=cls_props_target)
+        cls_props_dqt = [('tags', (set,)), ('name', (np.str_,)),
+                         ('reference', (np.str_,))]
 
         _DataQualityType = _base_class_factory('_DataQualityType', 'base',
-                                               class_attributes=cls_attr_dqt)
+                                               class_properties=cls_props_dqt)
 
-        cls_attr_rawdt = [('tags', (set,)),
-                          ('inc_angle', (np.ndarray, np.float_)),
-                          ('inc_angle_error', (np.ndarray, np.float_)),
-                          ('bearing', (np.ndarray, np.float_)),
-                          ('bearing_error', (np.ndarray, np.float_)),
-                          ('position', (np.ndarray, np.float_)),
-                          ('position_error', (np.ndarray, np.float_)),
-                          ('path_length', (np.ndarray, np.float_)),
-                          ('path_length_error', (np.ndarray, np.float_)),
-                          ('d_var', (np.ndarray, np.float_)),
-                          ('ind_var', (np.ndarray, np.float_)),
-                          ('datetime', (np.ndarray, datetime.datetime)),
-                          ('data_quality', (np.ndarray, np.float_)),
-                          ('integration_time', (np.ndarray, np.float_)),
-                          ('no_averages', (np.float_,)),
-                          ('temperature', (np.float_,)),
-                          ('user_notes', (np.str_,))]
+        cls_props_rawdt = [('tags', (set,)),
+                           ('inc_angle', (np.ndarray, np.float_)),
+                           ('inc_angle_error', (np.ndarray, np.float_)),
+                           ('bearing', (np.ndarray, np.float_)),
+                           ('bearing_error', (np.ndarray, np.float_)),
+                           ('position', (np.ndarray, np.float_)),
+                           ('position_error', (np.ndarray, np.float_)),
+                           ('path_length', (np.ndarray, np.float_)),
+                           ('path_length_error', (np.ndarray, np.float_)),
+                           ('d_var', (np.ndarray, np.float_)),
+                           ('ind_var', (np.ndarray, np.float_)),
+                           ('datetime', (np.ndarray, datetime.datetime)),
+                           ('data_quality', (np.ndarray, np.float_)),
+                           ('integration_time', (np.ndarray, np.float_)),
+                           ('no_averages', (np.float_,)),
+                           ('temperature', (np.float_,)),
+                           ('user_notes', (np.str_,))]
         cls_refr_rawdt = [('instrument', (_Instrument,)),
                           ('target', (_Target,)),
                           ('type', (_RawDataType,)),
@@ -490,10 +490,10 @@ class DatamodelTestCase(unittest.TestCase):
         h5f.create_earray('/', 'hash', tables.StringAtom(itemsize=28), (0,))
 
         TargetBuffer = _buffer_class_factory('TargetBuffer',
-                                             class_attributes=cls_attr_target)
+                                             class_properties=cls_props_target)
         DataQualityTypeBuffer = \
                 _buffer_class_factory('DataQualityTypeBuffer',
-                                      class_attributes=cls_attr_dqt)
+                                      class_properties=cls_props_dqt)
 
         dtb1 = DataQualityTypeBuffer(name='q-measure 1')
         dtb2 = DataQualityTypeBuffer(name='q-measure 2')
@@ -521,11 +521,11 @@ class DatamodelTestCase(unittest.TestCase):
         dt2 = _DataQualityType(group, dtb2)
 
         _RawData = _base_class_factory('_RawData', class_type='base',
-                                       class_attributes=cls_attr_rawdt,
+                                       class_properties=cls_props_rawdt,
                                        class_references=cls_refr_rawdt)
 
         RawDataBuffer = _buffer_class_factory('RawDataBuffer',
-                                              class_attributes=cls_attr_rawdt,
+                                              class_properties=cls_props_rawdt,
                                               class_references=cls_refr_rawdt)
         rdb = RawDataBuffer(d_var=np.zeros((1, 2048)), ind_var=np.arange(2048),
                             datetime=['2017-01-10T15:23:00'], no_averages=23,

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -66,16 +66,19 @@ class DatamodelTestCase(unittest.TestCase):
         r = d.new(rb)
         self.assertEqual(r.d_var.shape, (10, 2048))
         self.assertTrue(np.alltrue(r.d_var[0] < 1))
-        self.assertEqual(r.datetime[0], '2017-01-10T15:23:00')
+        self.assertEqual(r.datetime[0], np.datetime64('2017-01-10T15:23:00'))
 
     def test_PreferredFlux(self):
         d = Dataset(tempfile.mktemp(), 'w')
-        pfb = PreferredFluxBuffer(datetime=['2017-01-10T15:23:00',
+        pfb = PreferredFluxBuffer(flux_indices=[[2]],
+                                  datetime=['2017-01-10T15:23:00',
                                             '2017-01-11T15:23:00'])
         pf = d.new(pfb)
         np.testing.assert_array_equal(pf.datetime[:],
-                                      ['2017-01-10T15:23:00',
-                                       '2017-01-11T15:23:00'])
+                                      np.array(['2017-01-10T15:23:00',
+                                                '2017-01-11T15:23:00'],
+                                               dtype='datetime64[ms]'))
+        self.assertEqual(pf.flux_indices.shape, (1,1))
 
     def test_ResourceIdentifiers(self):
         d = Dataset(tempfile.mktemp(), 'w')
@@ -243,8 +246,9 @@ class DatamodelTestCase(unittest.TestCase):
         self.assertEqual(np.array(r.ind_var[:]).size, 4096)
         self.assertTrue(np.alltrue(np.array(r.d_var[:]) < 2))
         np.testing.assert_array_equal(np.array(r.datetime[:]).flatten(),
-                                      ['2017-01-10T15:23:00',
-                                       '2017-01-10T15:23:01'])
+                                      np.array(['2017-01-10T15:23:00',
+                                                '2017-01-10T15:23:01'],
+                                               dtype='datetime64[ms]'))
         with self.assertRaises(ValueError):
             r.append(rb1, pedantic=True)
         with self.assertRaises(ValueError):

--- a/tests/test_flyspecplugin.py
+++ b/tests/test_flyspecplugin.py
@@ -138,7 +138,8 @@ class FlySpecPluginTestCase(unittest.TestCase):
             nlines = len(fd.readlines())
         self.assertEqual(e['FluxBuffer'].value.shape, (nlines-1,))
         fb = e['FluxBuffer']
-        self.assertEqual(fb.datetime[-1], '2017-06-14T03:29:38.033000')
+        self.assertEqual(fb.datetime[-1], 
+                         np.datetime64('2017-06-14T03:29:38.033000'))
 
     def test_read_refspec(self):
         d = Dataset(tempfile.mktemp(), 'w')
@@ -168,7 +169,7 @@ class FlySpecPluginTestCase(unittest.TestCase):
         v = np.sqrt(vx*vx + vy*vy)
         self.assertAlmostEqual(v, 10.88, 2)
         self.assertAlmostEqual(vec2bearing(vx, vy), 255, 6)
-        self.assertEqual(dt, '2017-06-13T17:00:00')
+        self.assertEqual(dt, np.datetime64('2017-06-13T17:00:00'))
 
     @unittest.skip("Skipping")
     def test_plot(self):
@@ -250,20 +251,11 @@ class FlySpecPluginTestCase(unittest.TestCase):
         Read in a whole day's worth of data including the reference spectra,
         the flux results, and the wind data.
         """
-        def mycmp(fn1, fn2):
-            date1 = os.path.basename(fn1).split('.')[0]
-            date2 = os.path.basename(fn2).split('.')[0]
-            year, month, day, hourmin = date1.split('_')
-            d1 = datetime.datetime(int(year), int(month), int(day),
-                                   int(hourmin[0:2]), int(hourmin[2:]))
-            year, month, day, hourmin = date2.split('_')
-            d2 = datetime.datetime(int(year), int(month), int(day),
-                                   int(hourmin[0:2]), int(hourmin[2:]))
-            if d1 < d2:
-                return -1
-            if d1 > d2:
-                return 1
-            return 0
+        def keyfunc(fn):
+            date = os.path.basename(fn).split('.')[0]
+            year, month, day, hourmin = date.split('_')
+            return datetime.datetime(int(year), int(month), int(day),
+                                     int(hourmin[0:2]), int(hourmin[2:]))
 
         # Reference spectra
         fin_high = os.path.join(self.data_dir, 'TOFP04',
@@ -305,7 +297,7 @@ class FlySpecPluginTestCase(unittest.TestCase):
             rdlist.append(r)
 
         files = glob.glob(os.path.join(self.data_dir, 'TOFP04', '2017*.txt'))
-        files.sort(cmp=mycmp)
+        files = sorted(files, key=keyfunc)
         r = None
         c = None
         nlines = 0
@@ -347,9 +339,9 @@ class FlySpecPluginTestCase(unittest.TestCase):
         self.assertEqual(c.value[0], 119.93)
         self.assertEqual(c.value[-1], 23.30)
         self.assertEqual(c.rawdata[4].datetime[-1],
-                         '2017-06-14T04:30:00.535000')
+                         np.datetime64('2017-06-14T04:30:00.535'))
         self.assertEqual(c.rawdata[4].datetime[0],
-                         '2017-06-13T20:30:49.512999')
+                         np.datetime64('2017-06-13T20:30:49.512'))
         if False:
             with tempfile.TemporaryFile() as fd:
                 plot(c, savefig=fd)
@@ -402,7 +394,8 @@ class FlySpecPluginTestCase(unittest.TestCase):
         self.assertAlmostEqual(f.value[nos], 0.62, 2)
         self.assertEqual(rn.inc_angle[i0], 25.)
         self.assertEqual(rn.inc_angle[i1], 150.)
-        self.assertEqual(f.datetime[nos], '2017-06-13T21:20:17.196000')
+        self.assertEqual(f.datetime[nos],
+                         np.datetime64('2017-06-13T21:20:17.196000'))
 
         pfb = PreferredFluxBuffer(fluxes=[f],
                                   flux_indices=[[nos]],

--- a/tests/test_flyspecplugin.py
+++ b/tests/test_flyspecplugin.py
@@ -1,3 +1,8 @@
+from __future__ import division
+from __future__ import print_function
+from builtins import zip
+from builtins import range
+from past.utils import old_div
 import datetime
 import glob
 import inspect
@@ -48,8 +53,8 @@ class FlySpecPluginTestCase(unittest.TestCase):
         # any other fancy considerations. It also uses the alpha channel of
         # the images. Scaled by 255.
         rms = np.sqrt(
-            np.sum((255.0 * (expected_image - actual_image)) ** 2) /
-            float(expected_image.size))
+            old_div(np.sum((255.0 * (expected_image - actual_image)) ** 2),
+            float(expected_image.size)))
         return rms
 
     def test_add(self):
@@ -140,7 +145,7 @@ class FlySpecPluginTestCase(unittest.TestCase):
         x = [521, 637, 692, 818]
         y = [305., 315., 319.5, 330.]
         f = interp1d(x, y, fill_value='extrapolate')
-        xnew = range(0, 2048)
+        xnew = list(range(0, 2048))
         wavelengths = f(xnew)
 
         with self.assertRaises(FlySpecPluginException):
@@ -206,7 +211,7 @@ class FlySpecPluginTestCase(unittest.TestCase):
         x = [521, 637, 692, 818]
         y = [305., 315., 319.5, 330.]
         f = interp1d(x, y, fill_value='extrapolate')
-        xnew = range(0, 2048)
+        xnew = list(range(0, 2048))
         wavelengths = f(xnew)
         e = d.read(fin_txt, spectra=fin_bin, wavelengths=wavelengths,
                    ftype='flyspec', timeshift=12.0)
@@ -274,7 +279,7 @@ class FlySpecPluginTestCase(unittest.TestCase):
         x = [521, 637, 692, 818]
         y = [305., 315., 319.5, 330.]
         f = interp1d(x, y, fill_value='extrapolate')
-        xnew = range(0, 2048)
+        xnew = list(range(0, 2048))
         wavelengths = f(xnew)
 
         d = Dataset(tempfile.mktemp(), 'w')
@@ -334,7 +339,7 @@ class FlySpecPluginTestCase(unittest.TestCase):
                     last_index = last_index + cb.value.shape[0]
                     c.append(cb)
             except Exception as ex:
-                print(ex, _f, fin_bin)
+                print((ex, _f, fin_bin))
                 continue
         # Check all data has been read
         self.assertEqual(c.rawdata[4].d_var.shape, (nlines, 2048))

--- a/tests/test_flyspecplugin.py
+++ b/tests/test_flyspecplugin.py
@@ -1,8 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-from builtins import zip
-from builtins import range
-from past.utils import old_div
 import datetime
 import glob
 import inspect
@@ -53,8 +48,8 @@ class FlySpecPluginTestCase(unittest.TestCase):
         # any other fancy considerations. It also uses the alpha channel of
         # the images. Scaled by 255.
         rms = np.sqrt(
-            old_div(np.sum((255.0 * (expected_image - actual_image)) ** 2),
-            float(expected_image.size)))
+            np.sum((255.0 * (expected_image - actual_image)) ** 2) /
+            float(expected_image.size))
         return rms
 
     def test_add(self):
@@ -138,7 +133,7 @@ class FlySpecPluginTestCase(unittest.TestCase):
             nlines = len(fd.readlines())
         self.assertEqual(e['FluxBuffer'].value.shape, (nlines-1,))
         fb = e['FluxBuffer']
-        self.assertEqual(fb.datetime[-1], 
+        self.assertEqual(fb.datetime[-1],
                          np.datetime64('2017-06-14T03:29:38.033000'))
 
     def test_read_refspec(self):

--- a/tests/test_minidoasplugin.py
+++ b/tests/test_minidoasplugin.py
@@ -210,6 +210,8 @@ class MiniDoasPluginTestCase(unittest.TestCase):
                 m3 = _m
         if m3 is None:
             mb3 = e4['MethodBuffer']
+            import ipdb
+            ipdb.set_trace()
             new_description = mb3.description[0]
             new_description += '; plume geometry inferred from triangulation'
             mb3.description = new_description

--- a/tests/test_minidoasplugin.py
+++ b/tests/test_minidoasplugin.py
@@ -71,8 +71,10 @@ class MiniDoasPluginTestCase(unittest.TestCase):
         rb = e['RawDataBuffer']
         self.assertEqual(rb.d_var.shape, (7615, 482))
         self.assertEqual(rb.d_var[0, 0], 78)
-        self.assertEqual(rb.datetime[0], '2016-11-01T09:00:00.070000')
-        self.assertEqual(rb.datetime[-1], '2016-11-01T16:29:54.850000')
+        self.assertEqual(rb.datetime[0],
+                         np.datetime64('2016-11-01T09:00:00.070'))
+        self.assertEqual(rb.datetime[-1],
+                         np.datetime64('2016-11-01T16:29:54.850'))
 
         with self.assertRaises(MiniDoasException):
             e1 = d.read(os.path.join(self.data_dir, 'minidoas',
@@ -82,7 +84,8 @@ class MiniDoasPluginTestCase(unittest.TestCase):
                                  'NE_2016_11_01_Spectra.csv'),
                     date='2016-11-01', ftype='minidoas-spectra', timeshift=13)
         cb = e1['ConcentrationBuffer']
-        self.assertEqual(cb.datetime[-1], '2016-11-01T03:28:07.410000')
+        self.assertEqual(cb.datetime[-1],
+                         np.datetime64('2016-11-01T03:28:07.410'))
 
         fn_wd = os.path.join(self.data_dir, 'minidoas', 'wind',
                              '20161101_WD_00.txt')
@@ -94,7 +97,8 @@ class MiniDoasPluginTestCase(unittest.TestCase):
         gfb = e2['GasFlowBuffer']
         self.assertEqual(int(vec2bearing(gfb.vx[0], gfb.vy[0])), 240)
         self.assertAlmostEqual(np.sqrt(gfb.vx[0]**2 + gfb.vy[0]**2), 3.2, 1)
-        self.assertEqual(gfb.datetime[0], "2016-10-31T19:10:00")
+        self.assertEqual(gfb.datetime[0],
+                         np.datetime64("2016-10-31T19:10:00.000"))
         e3 = d.read(os.path.join(self.data_dir, 'minidoas',
                                  'XX_2016_11_01_Combined.csv'),
                     date='2016-11-01', ftype='minidoas-scan', station='NE',
@@ -102,7 +106,8 @@ class MiniDoasPluginTestCase(unittest.TestCase):
         fb = e3['FluxBuffer']
         np.testing.assert_array_almost_equal(fb.value[:],
                                              np.array([3.8, 1.2]), 1)
-        self.assertEqual(fb.datetime[0], '2016-10-31T23:15:04')
+        self.assertEqual(fb.datetime[0],
+                         np.datetime64('2016-10-31T23:15:04'))
 
     def read_single_station(self, d, station_info):
         """
@@ -210,8 +215,6 @@ class MiniDoasPluginTestCase(unittest.TestCase):
                 m3 = _m
         if m3 is None:
             mb3 = e4['MethodBuffer']
-            import ipdb
-            ipdb.set_trace()
             new_description = mb3.description[0]
             new_description += '; plume geometry inferred from triangulation'
             mb3.description = new_description

--- a/tests/test_minidoasplugin.py
+++ b/tests/test_minidoasplugin.py
@@ -141,7 +141,8 @@ class MiniDoasPluginTestCase(unittest.TestCase):
 
         # Read the concentration
         e1 = d.read(station_info['files']['spectra'],
-                    date='2016-11-01', ftype='minidoas-spectra', timeshift=13)
+                    date='2016-11-01', ftype='minidoas-spectra', timeshift=13,
+                    model=True)
         cb = e1['ConcentrationBuffer']
         idxs = np.zeros(cb.value.shape)
         for i in range(cb.value.shape[0]):

--- a/tests/test_nzmetserviceplugin.py
+++ b/tests/test_nzmetserviceplugin.py
@@ -35,7 +35,7 @@ class NZMetservicePluginTestCase(unittest.TestCase):
         self.assertAlmostEqual(v / 0.514444, 17, 6)
         self.assertAlmostEqual(70., vec2bearing(vx, vy), 6)
         m = gf.methods[0]
-        self.assertEqual(m.name[:][0], 'gfs')
+        self.assertEqual(m.name, 'gfs')
         d.read(os.path.join(self.data_dir,
                             'gns_wind_model_data_ecmwf_20160921_0630.txt'),
                ftype='NZMETSERVICE', preferred_model='ecmwf')
@@ -51,8 +51,8 @@ class NZMetservicePluginTestCase(unittest.TestCase):
         v = math.sqrt(vx * vx + vy * vy)
         self.assertAlmostEqual(v / 0.514444, 19, 6)
         self.assertAlmostEqual(65., vec2bearing(vx, vy), 6)
-        self.assertEqual(gf1.methods[0].name[:][0], 'ecmwf')
-        self.assertEqual(gf1.unit[:][0], 'm/s')
+        self.assertEqual(gf1.methods[0].name, 'ecmwf')
+        self.assertEqual(gf1.unit, 'm/s')
 
     def test_empty_model(self):
         d = Dataset(tempfile.mktemp(), 'w')

--- a/tests/verify_all_nzmetservice_data.py
+++ b/tests/verify_all_nzmetservice_data.py
@@ -54,7 +54,7 @@ def write_testfile(d, date, time, fin):
     but taking all the information from the GasFlow element.
     """
     gf = d.elements['GasFlow'][0]
-    mod = gf.methods[0].name[:][0]
+    mod = gf.methods[0].name
     year, month, day = int(date[0:4]), int(date[4:6]), int(date[6:8])
     hour, minute = int(time[0:2]), int(time[2:4])
     lines = []
@@ -87,7 +87,7 @@ def write_testfile(d, date, time, fin):
               astimezone(timezone('UTC')))
         otimes = np.unique(gf.datetime[:])
         otimes.sort()
-        for t in otimes:
+        for t in otimes.astype(np.str_):
             dt = timezone('UTC').localize(parse_iso_8601(t))
             times.append(dt)
             line += '{:<14s}'.format(dt.astimezone(nztz).strftime('%d%H%M'))


### PR DESCRIPTION
@nonbiostudent In the process of changing to Python 3 I have decided to re-write the class-factory. Apart from a lot of issues with the difference of how strings are handled in Python2 and Python3, the old factory was starting to become spaghetti code, hard to read and maintain. I think the new factory is much easier to understand and should also be more generic.

As I wasn't sure whether you are already using this code, I developed in a different branch before updating the main branch.

The new factory basically implements this pattern:

```
def property_factory(name):
    nname = '_'+name
   
    def setter(self, value):
        print('setter called')
        self.__dict__[nname] = value
    
    def getter(self):
        print('getter called')
        return self.__dict__[nname]
    
    return property(fget=getter, fset=setter)

def class_factory(name, properties):
    def __init__(self, **kwargs):
        print("init called")
        for key in self._properties:
            value = kwargs.pop(key, None)
            nkey = '_'+key
            self.__dict__[nkey] = value
    
    def __setattr__(self, key, value):
        print('setattr called')
        a = getattr(self.__class__, key, None)
        if isinstance(a, property):
            a.fset(self, value)
        else:
            print("{} is not an attribute of {}".format(key, self.__class__))
          
    cls_attrs = {'__init__': __init__,
                 '__setattr__': __setattr__}
    for _p in properties:
        cls_attrs[_p] = property_factory(_p)
    cls_attrs['_properties'] = properties
   
    return type(name, (object,), cls_attrs) 
```
